### PR TITLE
Fix failed to obtain client from authgear server

### DIFF
--- a/authgear/values.yaml
+++ b/authgear/values.yaml
@@ -48,6 +48,10 @@ traefik:
       cpu: "300m"
       memory: "256Mi"
 
+  service:
+    spec:
+      externalTrafficPolicy: Local
+
 # The values of this chart.
 authgear:
   appNamespace: "authgear-apps"


### PR DESCRIPTION
fix #1 

Deployed to staging and production cloud.

1. ~~In the current infrastructure, will the pod call another pod through external dns? If we have this case, we may need to change traefik to daemonset. Currently it is deployment, so it is using less resources.~~ Check and test, using deployment for traefik is fine, portal route to admin is using cluster dns so won't be affect in this case.
2. ~~Not sure if we need to set `TRUST_PROXY` to true in this setup, need testing when applying the changes.~~ After changing externalTrafficPolicy, the remote address is client ip already, don't need to set `TRUST_PROXY` to obtain ip from other headers.