### PR TITLE
Support extraVolumes and extraVolumeMounts

### DIFF
--- a/authgear/templates/authgear-admin-server.yaml
+++ b/authgear/templates/authgear-admin-server.yaml
@@ -15,21 +15,27 @@ spec:
         {{- include "authgear.adminSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "authgear.nameMain" . | quote }}
-      {{ if .Values.authgear.appCustomResources.path }}
       volumes:
+      {{- if .Values.authgear.appCustomResources.path }}
       - name: custom-resources
         {{- toYaml .Values.authgear.appCustomResources.volume | nindent 8 }}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
+      {{- end }}
       containers:
       - name: authgear-admin-server
         image: {{ .Values.authgear.mainServer.image | quote }}
         imagePullPolicy: Always
         args: ["authgear", "start", "admin"]
-        {{ if .Values.authgear.appCustomResources.path }}
         volumeMounts:
+        {{- if .Values.authgear.appCustomResources.path }}
         - name: custom-resources
           mountPath: {{ .Values.authgear.appCustomResources.path | quote }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         - name: DATABASE_URL
           value: {{ .Values.authgear.databaseURL | quote }}

--- a/authgear/templates/authgear-background.yaml
+++ b/authgear/templates/authgear-background.yaml
@@ -14,21 +14,27 @@ spec:
       labels:
         {{- include "authgear.backgroundSelectorLabels" . | nindent 8 }}
     spec:
-      {{ if .Values.authgear.appCustomResources.path }}
       volumes:
+      {{- if .Values.authgear.appCustomResources.path }}
       - name: custom-resources
         {{- toYaml .Values.authgear.appCustomResources.volume | nindent 8 }}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
+      {{- end }}
       containers:
       - name: authgear-background
         image: {{ .Values.authgear.mainServer.image | quote }}
         imagePullPolicy: Always
         args: ["authgear", "background"]
-        {{ if .Values.authgear.appCustomResources.path }}
         volumeMounts:
+        {{- if .Values.authgear.appCustomResources.path }}
         - name: custom-resources
           mountPath: {{ .Values.authgear.appCustomResources.path | quote }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         - name: DATABASE_URL
           value: {{ .Values.authgear.databaseURL | quote }}

--- a/authgear/templates/authgear-images-server.yaml
+++ b/authgear/templates/authgear-images-server.yaml
@@ -9,7 +9,6 @@ data:
   credentials.json: {{ .Values.authgear.imagesServer.objectStore.gcpGCS.credentialsJSONContent | quote }}
 {{- end }}
 ---
-{{ $has_volumes := (or .Values.authgear.appCustomResources.path (eq .Values.authgear.imagesServer.objectStore.type "GCP_GCS")) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +26,6 @@ spec:
         {{- include "authgear.imagesSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "authgear.nameMain" . | quote }}
-      {{- if $has_volumes }}
       volumes:
       {{- if .Values.authgear.appCustomResources.path }}
       - name: custom-resources
@@ -38,13 +36,14 @@ spec:
         configMap:
           name: {{ include "authgear.nameImages" . | quote }}
       {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
       {{- end }}
       containers:
       - name: authgear-images-server
         image: {{ .Values.authgear.mainServer.image | quote }}
         imagePullPolicy: Always
         args: ["authgear", "images", "start"]
-        {{- if $has_volumes }}
         volumeMounts:
         {{- if .Values.authgear.appCustomResources.path }}
         - name: custom-resources
@@ -54,6 +53,8 @@ spec:
         - name: gcp-credentials
           mountPath: /var/authgear/images/gcp
         {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
         {{- end }}
         env:
         - name: DATABASE_URL

--- a/authgear/templates/authgear-main-server.yaml
+++ b/authgear/templates/authgear-main-server.yaml
@@ -54,21 +54,27 @@ spec:
         {{- include "authgear.mainSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "authgear.nameMain" . | quote }}
-      {{ if .Values.authgear.appCustomResources.path }}
       volumes:
+      {{- if .Values.authgear.appCustomResources.path }}
       - name: custom-resources
         {{- toYaml .Values.authgear.appCustomResources.volume | nindent 8 }}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
+      {{- end }}
       containers:
       - name: authgear-main-server
         image: {{ .Values.authgear.mainServer.image | quote }}
         imagePullPolicy: Always
         args: ["authgear", "start", "main"]
-        {{ if .Values.authgear.appCustomResources.path }}
         volumeMounts:
+        {{- if .Values.authgear.appCustomResources.path }}
         - name: custom-resources
           mountPath: {{ .Values.authgear.appCustomResources.path | quote }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         - name: DATABASE_URL
           value: {{ .Values.authgear.databaseURL | quote }}

--- a/authgear/templates/authgear-portal-server.yaml
+++ b/authgear/templates/authgear-portal-server.yaml
@@ -138,14 +138,17 @@ spec:
           items:
           - key: ingress.tpl.yaml
             path: ingress.tpl.yaml
-      {{ if .Values.authgear.appCustomResources.path }}
+      {{- if .Values.authgear.appCustomResources.path }}
       - name: app-custom-resources
         {{- toYaml .Values.authgear.appCustomResources.volume | nindent 8 }}
-      {{ end }}
-      {{ if .Values.authgear.portalCustomResources.path }}
+      {{- end }}
+      {{- if .Values.authgear.portalCustomResources.path }}
       - name: portal-custom-resources
         {{- toYaml .Values.authgear.portalCustomResources.volume | nindent 8 }}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
+      {{- end }}
       containers:
       - name: authgear-portal-server-proxy
         image: {{ .Values.authgear.portalServerProxy.image | quote }}
@@ -164,14 +167,17 @@ spec:
         volumeMounts:
         - name: volume-ingress-template
           mountPath: /app/configmap/ingress-template
-        {{ if .Values.authgear.appCustomResources.path }}
+        {{- if .Values.authgear.appCustomResources.path }}
         - name: app-custom-resources
           mountPath: {{ .Values.authgear.appCustomResources.path | quote }}
-        {{ end }}
-        {{ if .Values.authgear.portalCustomResources.path }}
+        {{- end }}
+        {{- if .Values.authgear.portalCustomResources.path }}
         - name: portal-custom-resources
           mountPath: {{ .Values.authgear.portalCustomResources.path | quote }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         - name: DATABASE_URL
           value: {{ .Values.authgear.databaseURL | quote }}

--- a/authgear/templates/authgear-resolver-server.yaml
+++ b/authgear/templates/authgear-resolver-server.yaml
@@ -15,21 +15,27 @@ spec:
         {{- include "authgear.resolverSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "authgear.nameMain" . | quote }}
-      {{ if .Values.authgear.appCustomResources.path }}
       volumes:
+      {{- if .Values.authgear.appCustomResources.path }}
       - name: custom-resources
         {{- toYaml .Values.authgear.appCustomResources.volume | nindent 8 }}
-      {{ end }}
+      {{- end }}
+      {{- if .Values.authgear.extraVolumes }}
+      {{- toYaml .Values.authgear.extraVolumes | nindent 6 }}
+      {{- end }}
       containers:
       - name: authgear-resolver-server
         image: {{ .Values.authgear.mainServer.image | quote }}
         imagePullPolicy: Always
         args: ["authgear", "start", "resolver"]
-        {{ if .Values.authgear.appCustomResources.path }}
         volumeMounts:
+        {{- if .Values.authgear.appCustomResources.path }}
         - name: custom-resources
           mountPath: {{ .Values.authgear.appCustomResources.path | quote }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.authgear.extraVolumeMounts }}
+        {{- toYaml .Values.authgear.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         - name: DATABASE_URL
           value: {{ .Values.authgear.databaseURL | quote }}

--- a/authgear/values.yaml
+++ b/authgear/values.yaml
@@ -211,3 +211,7 @@ authgear:
   portalCustomResources:
     path: ""
     volume: {}
+
+  extraVolumes: []
+
+  extraVolumeMounts: []


### PR DESCRIPTION
fix #14

I realize that it is legal to have empty value for `volumes` and `volumeMounts`. That is

```
volumes:
containers:
```

is legal.