### PR TITLE
Migrate ingress class annotation to ingressClassName field

### DIFF
--- a/authgear/templates/ingress-template.yaml
+++ b/authgear/templates/ingress-template.yaml
@@ -12,13 +12,13 @@ data:
     metadata:
       name: nginx-{{ "{{ .Host }}" }}
       annotations:
-        kubernetes.io/ingress.class: {{ $.Values.authgear.ingress.class | quote }}
         {{- with $.Values.authgear.ingress.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         app.kubernetes.io/managed-by: authgear
     spec:
+      ingressClassName: {{ $.Values.authgear.ingress.class | quote }}
       tls:
       - hosts:
         - {{ "{{ .Host }}" }}

--- a/authgear/templates/portal-ingress.yaml
+++ b/authgear/templates/portal-ingress.yaml
@@ -18,7 +18,6 @@ kind: Ingress
 metadata:
   name: {{ include "authgear.namePortal" . }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.authgear.ingress.class | quote }}
     {{- with $.Values.authgear.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -28,6 +27,7 @@ metadata:
   labels:
     {{- include "authgear.labels" . | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.authgear.ingress.class | quote }}
   {{- if .Values.authgear.tls.portal.ingress.tls.enabled }}
   tls:
   - secretName: {{ $portalSecretName | quote }}
@@ -75,7 +75,6 @@ kind: Ingress
 metadata:
   name: {{ include "authgear.namePortalAuthgear" . }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.authgear.ingress.class | quote }}
     {{- with $.Values.authgear.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -85,6 +84,7 @@ metadata:
   labels:
     {{- include "authgear.labels" . | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.authgear.ingress.class | quote }}
   {{- if .Values.authgear.tls.portalAuthgear.ingress.tls.enabled }}
   tls:
   - secretName: {{ $portalAuthgearSecretName | quote }}

--- a/authgear/templates/siteadmin-ingress.yaml
+++ b/authgear/templates/siteadmin-ingress.yaml
@@ -13,7 +13,6 @@ kind: Ingress
 metadata:
   name: {{ include "authgear.nameSiteadmin" . | quote }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.authgear.ingress.class | quote }}
     {{- with $.Values.authgear.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -23,6 +22,7 @@ metadata:
   labels:
     {{- include "authgear.labels" . | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.authgear.ingress.class | quote }}
   {{- if .Values.authgear.tls.siteadmin.ingress.tls.enabled }}
   tls:
   - secretName: {{ $siteadminSecretName | quote }}

--- a/authgear/templates/wildcard-ingress.yaml
+++ b/authgear/templates/wildcard-ingress.yaml
@@ -9,7 +9,6 @@ kind: Ingress
 metadata:
   name: {{ $defaultDomain.domain | quote }}
   annotations:
-    kubernetes.io/ingress.class: {{ $.Values.authgear.ingress.class | quote }}
     {{- with $.Values.authgear.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -19,6 +18,7 @@ metadata:
   labels:
     {{- include "authgear.labels" $ | nindent 4 }}
 spec:
+  ingressClassName: {{ $.Values.authgear.ingress.class | quote }}
   {{- if $defaultDomain.ingress.tls.enabled }}
   tls:
   - secretName: {{ $defaultDomain.secretName | quote }}


### PR DESCRIPTION
Replace deprecated kubernetes.io/ingress.class annotation with the spec.ingressClassName field across all ingress templates.